### PR TITLE
Add option to bold steps

### DIFF
--- a/template/template.typ
+++ b/template/template.typ
@@ -101,13 +101,21 @@
   }
 )
 
-#let step(a, b) = {
+#let step(a, b, bold: false) = {
   if ((a != none and a != "") or (b != none and b != "")) {
-    a
+    if bold {
+      strong(a)
+    } else {
+      a
+    }
     " "
     box(width: 1fr, repeat[.])
     " "
-    b
+    if bold {
+      strong(b)
+    } else {
+      b
+    }
     linebreak()
   }
 }


### PR DESCRIPTION
This PR suggests the addition of the `bold` parameter on steps.

![image](https://github.com/user-attachments/assets/9809e5f6-a8d0-4c25-94ec-bc45b554048a)

```typst
  #section("In harbour", fill-clr: yellow)[
    #step("Traffic", "Checked and called")
    #step("Speed", "Maintain below 4 kts")
    #step("", "After leaving aisle", bold: true)
    #step("Fenders", "Flipped and secured")
    #step("Boat hook", "Secured below decks")
  ]
```