### PR TITLE
Add `disclaimer-fill` arg to input custom accent colors

### DIFF
--- a/template/template.typ
+++ b/template/template.typ
@@ -150,6 +150,7 @@
   title: none,
   disclaimer: none,
   font: "Open Sans",
+  disclaimer-fill: rgb("FF1100").lighten(40%),
   style: 0,
   body,
 ) = {
@@ -195,7 +196,7 @@
   }
 
   if disclaimer != none {
-    box(width: 100%, stroke: 1pt, outset: 4pt, fill: rgb("FF1100").lighten(40%))[
+    box(width: 100%, stroke: 1pt, outset: 4pt, fill: disclaimer-fill)[
       #v(5pt)
       #align(center)[#text(size: 20pt, upper(strong(disclaimer)))]
       #v(5pt)


### PR DESCRIPTION
Same as the `font` arg, but for the accent color.