### PR TITLE
Add `size`, `title`, `outset` args for further customization

### DIFF
--- a/template/template.typ
+++ b/template/template.typ
@@ -58,9 +58,11 @@
 #let topic(
   title,
   fill-clr: rgb("FFFFFF"),
+  stroke: 1pt,
+  outset: 4pt,
   body,
 ) = {
-  box(width: 100%, stroke: 1pt, outset: 4pt, fill: fill-clr)[
+  box(width: 100%, stroke: stroke, outset: outset, fill: fill-clr)[
     #v(5pt)
     #align(center)[#text(size: 20pt, upper(strong(title)))]
     #v(5pt)
@@ -73,11 +75,13 @@
 #let section(
   title,
   fill-clr: rgb("FFFFFF"),
+  stroke: 1pt,
+  outset: 4pt,
   body,
 ) = (
   context {
     if (title != none and title != "") {
-      box(width: 100%, stroke: 1pt, outset: 4pt, fill: fill-clr)[
+      box(width: 100%, stroke: stroke, outset: outset, fill: fill-clr)[
         #v(5pt)
         #align(center)[#upper(strong(title))]
         #v(5pt)
@@ -85,7 +89,7 @@
       linebreak()
       v(-(small-text-size))
       if (style-state.get() == 1) {
-        box(width: 1fr, stroke: 1pt, outset: 4pt)[
+        box(width: 1fr, stroke: stroke, outset: outset)[
           #v(5pt)
           #body
           #v(5pt)
@@ -151,6 +155,10 @@
   disclaimer: none,
   font: "Open Sans",
   style: 0,
+  text-size: large-text-size,
+  title-stroke: 1pt,
+  disclaimer-stroke: 1pt,
+  outset: 4pt,
   body,
 ) = {
   set page(
@@ -182,12 +190,12 @@
     ],
   )
 
-  set text(size: large-text-size, font: font)
+  set text(size: text-size, font: font)
 
   style-state.update(style)
 
   if title != none {
-    box(width: 100%, stroke: 1pt, outset: 4pt, fill: rgb("FFFFFF"))[
+    box(width: 100%, stroke: title-stroke, outset: outset, fill: rgb("FFFFFF"))[
       #v(5pt)
       #align(center)[#text(size: 20pt, upper(strong(title)))]
       #v(5pt)
@@ -195,7 +203,7 @@
   }
 
   if disclaimer != none {
-    box(width: 100%, stroke: 1pt, outset: 4pt, fill: rgb("FF1100").lighten(40%))[
+    box(width: 100%, stroke: disclaimer-stroke, outset: outset, fill: rgb("FF1100").lighten(40%))[
       #v(5pt)
       #align(center)[#text(size: 20pt, upper(strong(disclaimer)))]
       #v(5pt)


### PR DESCRIPTION
A few more arguments to control things further. Preserved previous values where possible.

This allows the `checklist()` ones to be set with:
```typst
#show: checklist.with(
  title-stroke: (bottom: 0.25em),
  disclaimer-stroke: 0em,
  size: 14pt,
)
```

And `topic` and `section` ones by assigning them immediately after:
```typst
#let (topic, section) = (
  topic.with(stroke: (bottom: 0.15em), outset: 0pt),
  section.with(stroke: (bottom: 0.15em), outset: 0pt),
)
```

Suggest you check those values with [`BN Islander.typ`], and a font like `Graphik` or your favorite sans. It results in a visually clean result that is much more pleasant, after we've controlled the outset width and strokes.

If you like it, you'd have my permission to add them in a `style: 2`.

Cheers! 🎉

[`BN Islander.typ`]: https://github.com/TomVer99/Typst-checklist-template/blob/main/examples/BN%20Islander.typ